### PR TITLE
Refactor Robot to support optional delayToRelease for Mouse Events

### DIFF
--- a/src/org/safs/robot/Robot.java
+++ b/src/org/safs/robot/Robot.java
@@ -56,6 +56,7 @@ import org.safs.tools.stringutils.StringUtilities;
  * Utility functions for common user interactions on the system.
  * 
  * @author canagl Sept 09, 2008
+ * <br> SEP 30, 2015 CANAGL Add configurable delay between mouse down and mouse up.
  * @see java.awt.Robot
  * @see org.safs.tools.input.CreateUnicodeMap
  * @see org.safs.tools.input.InputKeysParser
@@ -67,6 +68,9 @@ public class Robot {
 	private static InputKeysParser keysparser = null;
 	
 	private static int millisBetweenKeystrokes = 1;
+	
+	/** 800 */
+	public static final int DEFAULT_MILLIS_BETWEEN_MOUSE_RELEASE = 800;
 	
 	/**
 	 * To make mouse drag correctly, after mouse key is pressed down, 
@@ -362,6 +366,37 @@ public class Robot {
 	 * @param y screen Y coordinate
 	 * @param buttonmask -- specific InputEvent.BUTTONn_MASK(s) 
 	 * @param nclicks -- number of times to click (press and release)
+	 * @param delayToRelease -- number of millis to wait before final Release.
+	 * @return Object Currently we return a Boolean(true) object, but this may 
+	 * be subject to change.
+	 * 
+	 * @throws java.awt.AWTException
+	 * @see java.awt.Robot#mousePress(int)
+	 * @see java.awt.event.InputEvent#BUTTON1_MASK
+	 */
+	public static Object click(int x, int y, int buttonmask, int nclicks, int delayToRelease)throws java.awt.AWTException{
+		java.awt.Robot bot = getRobot();
+		Log.info("Robot click at:"+ x +","+ y +" using button mask "+ buttonmask +" "+ nclicks +" times with release delay "+ delayToRelease);
+		bot.mouseMove(x, y);
+		for(int i = 0; i < nclicks; i++){
+			bot.mousePress(buttonmask);
+			if(i == nclicks-1) {
+				bot.delay(delayToRelease);
+			}
+			bot.mouseRelease(buttonmask);
+		}
+		return new Boolean(true);
+	}
+	
+	/**
+	 * Workhorse Click routine.  
+	 * Allows us to Click--Press & Release--any combination of InputEvent.BUTTONn_MASK 
+	 * any number of times. 
+	 * 
+	 * @param x screen X coordinate
+	 * @param y screen Y coordinate
+	 * @param buttonmask -- specific InputEvent.BUTTONn_MASK(s) 
+	 * @param nclicks -- number of times to click (press and release)
 	 * @return Object Currently we return a Boolean(true) object, but this may 
 	 * be subject to change.
 	 * 
@@ -370,16 +405,37 @@ public class Robot {
 	 * @see java.awt.event.InputEvent#BUTTON1_MASK
 	 */
 	public static Object click(int x, int y, int buttonmask, int nclicks)throws java.awt.AWTException{
-		java.awt.Robot bot = getRobot();
-		Log.info("Robot click at:"+ x +","+ y +" using button mask "+ buttonmask +" "+ nclicks +" times.");
-		bot.mouseMove(x, y);
-		for(int i = 0; i < nclicks; i++){
-			bot.mousePress(buttonmask);
-			bot.mouseRelease(buttonmask);
-		}
-		return new Boolean(true);
+		return click(x, y, buttonmask, nclicks, 1);
 	}
 	
+	/**
+	 * Workhorse Click with Keypress routine.  
+	 * Allows us to Click--Press & Release--any combination of InputEvent.BUTTONn_MASK 
+	 * any number of times with a single Key Press & Release. 
+	 * 
+	 * @param x screen X coordinate
+	 * @param y screen Y coordinate
+	 * @param buttonmask -- specific InputEvent.BUTTONn_MASK(s) 
+	 * @param keycode -- specific keycode to press & release. Ex: KeyEvent.VK_SHIFT 
+	 * @param nclicks -- number of times to click (press and release)
+	 * @param delayToRelease -- number of millis to wait before final Release.
+	 * @return Object Currently we return a Boolean(true) object, but this may 
+	 * be subject to change.
+	 * 
+	 * @throws java.awt.AWTException
+	 * @see java.awt.Robot#mousePress(int)
+	 * @see java.awt.event.InputEvent#BUTTON1_MASK
+	 */
+	public static Object clickWithKeyPress(int x, int y, int buttonmask, int keycode, int nclicks, int delayToRelease)throws java.awt.AWTException{
+		java.awt.Robot bot = getRobot();
+		Log.info("Robot click at:"+ x +","+ y +" using button mask "+ buttonmask +", keycode "+ keycode +", "+ nclicks +" times with delay to release "+ delayToRelease);
+		bot.mouseMove(x, y);
+		bot.keyPress(keycode);
+		click(x,y,buttonmask,nclicks,delayToRelease);
+		bot.keyRelease(keycode);
+		return new Boolean(true);
+	}
+
 	/**
 	 * Workhorse Click with Keypress routine.  
 	 * Allows us to Click--Press & Release--any combination of InputEvent.BUTTONn_MASK 
@@ -398,16 +454,22 @@ public class Robot {
 	 * @see java.awt.event.InputEvent#BUTTON1_MASK
 	 */
 	public static Object clickWithKeyPress(int x, int y, int buttonmask, int keycode, int nclicks)throws java.awt.AWTException{
-		java.awt.Robot bot = getRobot();
-		Log.info("Robot click at:"+ x +","+ y +" using button mask "+ buttonmask +", keycode "+ keycode +", "+ nclicks +" times.");
-		bot.mouseMove(x, y);
-		bot.keyPress(keycode);
-		for(int i = 0; i < nclicks; i++){
-			bot.mousePress(buttonmask);
-			bot.mouseRelease(buttonmask);
-		}
-		bot.keyRelease(keycode);
-		return new Boolean(true);
+		return clickWithKeyPress(x, y, buttonmask, keycode, nclicks, 1);
+	}
+
+	/**
+	 * Move the mouse cursor to the specified x,y coordinates then perform a 
+	 * single mousePress and Release to execute a Click.
+	 * @param x
+	 * @param y
+	 * @param delayToRelease -- number of millis to wait before final Release.
+	 * @return Object Currently we return a Boolean(true) object, but this may 
+	 * be subject to change.
+	 * @throws java.awt.AWTException if instantiating java.awt.Robot throws it.
+	 * @see java.awt.Robot
+	 */
+	public static Object click(int x, int y, int delayToRelease) throws java.awt.AWTException{
+		return click(x,y,InputEvent.BUTTON1_MASK,1, delayToRelease);
 	}
 
 	/**
@@ -421,13 +483,13 @@ public class Robot {
 	 * @see java.awt.Robot
 	 */
 	public static Object click(int x, int y) throws java.awt.AWTException{
-		return click(x,y,InputEvent.BUTTON1_MASK,1);
+		return click(x,y,1);
 	}
 
 	
 	/**
 	 * Move the mouse cursor to the specified x,y coordinates then perform a 
-	 * single mousePress and Release to execute a Click.
+	 * double mousePress and Release to execute a Click.
 	 * @param x
 	 * @param y
 	 * @return Object Currently we return a Boolean(true) object, but this may 
@@ -450,7 +512,22 @@ public class Robot {
 	 * @see java.awt.Robot
 	 */
 	public static Object rightClick(int x, int y) throws java.awt.AWTException{
-		return click(x,y,InputEvent.BUTTON3_MASK,1);
+		return click(x,y,InputEvent.BUTTON3_MASK,1, 1);
+	}
+
+	/**
+	 * Move the mouse cursor to the specified x,y coordinates then perform a 
+	 * single mousePress and Release to execute a RightClick.
+	 * @param x
+	 * @param y
+	 * @param delayToRelease millis between final release.
+	 * @return Object Currently we return a Boolean(true) object, but this may 
+	 * be subject to change.
+	 * @throws java.awt.AWTException if instantiating java.awt.Robot throws it.
+	 * @see java.awt.Robot
+	 */
+	public static Object rightClick(int x, int y, int delayToRelease) throws java.awt.AWTException{
+		return click(x,y,InputEvent.BUTTON3_MASK,1, delayToRelease);
 	}
 
 	
@@ -502,12 +579,13 @@ public class Robot {
 	 * @param Point screen coordinates to start of mouse press and drag.
 	 * @param Point screen coordinates to end mouse drag and mouse release.
 	 * @param int button masks to use during drag
+	 * @param delayToRelease millis before final release.
 	 * @return Object Currently we return a Boolean(true) object, but this may 
 	 * be subject to change.
 	 * @throws java.awt.AWTException if instantiating java.awt.Robot throws it.
 	 * @see java.awt.Robot
 	 */
-	public static Object mouseDrag(java.awt.Point start, java.awt.Point end, int buttonMasks) throws java.awt.AWTException{
+	public static Object mouseDrag(java.awt.Point start, java.awt.Point end, int buttonMasks, int delayToRelease) throws java.awt.AWTException{
 		java.awt.Robot bot = getRobot();
 		Log.info("Robot mouseDrag from:"+ start +" to:"+ end +" using button mask "+ buttonMasks);
 		bot.mouseMove(start.x, start.y);
@@ -519,9 +597,24 @@ public class Robot {
 		bot.mouseMove(end.x+dragEndPointOffset.x, end.y+dragEndPointOffset.y);
 		bot.delay(150);
 		bot.mouseMove(end.x, end.y);
-		bot.delay(800);
+		bot.delay(delayToRelease);
 	    bot.mouseRelease(buttonMasks);
 		return new Boolean(true);
+	}
+
+	/**
+	 * Move the mouse cursor to the specified start Point coordinates then perform a 
+	 * single mousePress using buttonMasks and drag\move then Release the mouse button at the end point.
+	 * @param Point screen coordinates to start of mouse press and drag.
+	 * @param Point screen coordinates to end mouse drag and mouse release.
+	 * @param int button masks to use during drag
+	 * @return Object Currently we return a Boolean(true) object, but this may 
+	 * be subject to change.
+	 * @throws java.awt.AWTException if instantiating java.awt.Robot throws it.
+	 * @see java.awt.Robot
+	 */
+	public static Object mouseDrag(java.awt.Point start, java.awt.Point end, int buttonMasks) throws java.awt.AWTException{
+		return mouseDrag(start, end, buttonMasks, DEFAULT_MILLIS_BETWEEN_MOUSE_RELEASE);
 	}
 	
 	/**


### PR DESCRIPTION
The intent is to support Click+Hold for an arbitrary amount of time for
certain types of click and/or drag commands.  This refactoring should
allow existing tests and usage to work unmodified while exposing the
ability to call overloaded routines that can receive delayToRelease hold
times.

The full Regression test was run and no Robot Click or Drag failures occurred that could be attributed to these code changes.  There was 1 Drag failure, but that was a "item not found within timeout 30" failure.
