### PR TITLE
Basic CallJUnit support in the Core framework

### DIFF
--- a/src/org/safs/DriverCommand.java
+++ b/src/org/safs/DriverCommand.java
@@ -15,11 +15,7 @@ package org.safs;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
-import org.junit.runner.notification.Failure;
 import org.safs.model.commands.DDDriverFlowCommands;
 import org.safs.text.FAILStrings;
 import org.safs.text.GENStrings;
@@ -193,70 +189,6 @@ public abstract class DriverCommand extends Processor {
 		  onGUIGotoCommands(true);
 	  } else if(command.equalsIgnoreCase(DDDriverFlowCommands.ONGUINOTEXISTGOTOBLOCKID_KEYWORD)){
 		  onGUIGotoCommands(false);
-	  } else if(command.equalsIgnoreCase(DDDriverFlowCommands.CALLSCRIPT_KEYWORD)){
-		  callScript();
-	  }
-  }
-  
-  public static String callJUnitScript(String classname) throws ClassNotFoundException, SAFSException{
-	  String debugmsg = StringUtils.debugmsg(false);
-
-	  JUnitCore junit = new JUnitCore();
-	  Result jresult = junit.run(Class.forName(classname));
-
-	  if(jresult == null){
-		  String detail = "JUnit execution returned a null Result.";
-		  throw new SAFSException(detail);
-	  }else{
-		  StringBuffer sb = new StringBuffer();
-		  sb.append(jresult.getRunCount()+ " tests run.\n");
-		  sb.append(jresult.getIgnoreCount()+" tests ignored.\n");
-		  sb.append(jresult.getFailureCount()+ " tests failed.\n");
-		  sb.append("Runtime: "+ jresult.getRunTime() +" milliseconds.\n");
-		  List<Failure> failures = jresult.getFailures();
-		  sb.append("");
-		  for(Failure failure:failures){
-			  sb.append("   "+ failure.toString()+"\n");
-			  sb.append("\n");
-		  }
-		  IndependantLog.debug(debugmsg+" succeeded with result:\n "+sb.toString());
-		  return sb.toString();
-	  }   
-
-  }
-  
-  private void callScript(){
-	  if (params.size() < 1) {
-		  this.issueParameterCountFailure("ScriptName");
-		  return;
-	  }
-
-	  testRecordData.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
-	  String debugmsg = StringUtils.debugmsg(false);
-
-	  Iterator iterator = params.iterator();
-	  String scriptName = (String) iterator.next();
-	  IndependantLog.info(debugmsg+"............................. handling [JUnit] script: "+scriptName);
-	  try {
-		  String result = callJUnitScript(scriptName);
-
-		  log.logMessage(testRecordData.getFac(),
-				  genericText.convert(TXT_SUCCESS_2,
-						  getTestRecordData().getCommand()+" "+ scriptName +" successful.",
-						  getTestRecordData().getCommand(), scriptName),
-						  GENERIC_MESSAGE,
-						  result);
-		  testRecordData.setStatusCode(StatusCodes.NO_SCRIPT_FAILURE);
-	  } catch (ClassNotFoundException e) {
-		  //This will not be considered as a failure, the script will be tried in a specific engine later. Just log a warning.
-		  IndependantLog.warn(debugmsg+"'"+scriptName+"' was not executed! Due to "+StringUtils.debugmsg(e));
-		  testRecordData.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
-	  } catch (SAFSException e) {
-		  String detail = e.getMessage();
-		  String errmsg = FAILStrings.convert(FAILStrings.SCRIPT_ERROR, "Script '"+ scriptName +"' error: "+ detail, scriptName, detail);
-		  IndependantLog.error(debugmsg+errmsg);
-		  issueErrorPerformingAction(errmsg);
-		  testRecordData.setStatusCode(StatusCodes.GENERAL_SCRIPT_FAILURE);
 	  }
   }
   

--- a/src/org/safs/selenium/webdriver/SeleniumPlus.java
+++ b/src/org/safs/selenium/webdriver/SeleniumPlus.java
@@ -64,31 +64,18 @@ package org.safs.selenium.webdriver;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.geom.Point2D;
-import java.io.CharArrayWriter;
-import java.io.File;
-import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import javax.script.Bindings;
-import javax.script.CompiledScript;
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-
-import org.codehaus.groovy.jsr223.GroovyCompiledScript;
-import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
-import org.junit.runner.notification.Failure;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriver.Timeouts;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.SessionNotFoundException;
 import org.safs.ComponentFunction;
+import org.safs.DriverCommand;
 import org.safs.IndependantLog;
 import org.safs.JavaHook;
 import org.safs.Processor;
@@ -135,7 +122,6 @@ import org.safs.text.FileUtilities.Mode;
 import org.safs.text.FileUtilities.PatternFilterMode;
 import org.safs.text.FileUtilities.Placement;
 import org.safs.text.GENStrings;
-import org.safs.tools.CaseInsensitiveFile;
 import org.safs.tools.MainClass;
 import org.safs.tools.counters.CountStatusInterface;
 import org.safs.tools.counters.CountersInterface;
@@ -10644,26 +10630,13 @@ public abstract class SeleniumPlus {
 					// TODO
 					System.out.println(badpath+" No filepath.");
 				}else{
-					System.out.println("-script '"+ _script +"' will now execute.");
-
-					JUnitCore junit = new JUnitCore();
-					Result jresult = junit.run(Class.forName(_script));
-					
-					if(jresult == null){
-						System.out.println("JUnit execution returned a null Result.");
-					}else{
-						System.out.println(jresult.getRunCount()+ " tests run.");
-						System.out.println(jresult.getIgnoreCount()+" tests ignored.");
-						System.out.println(jresult.getFailureCount()+ " tests failed.");
-						System.out.println("Runtime: "+ jresult.getRunTime() +" milliseconds.");
-						List<Failure> failures = jresult.getFailures();
-						int i =1;
-						System.out.println("");
-						for(Failure failure:failures){
-							System.out.println("   "+ failure.toString());
-							System.out.println("");
-						}
-					}					
+					try{
+						System.out.println("SeleniumPlus -script '"+ _script +"' will now execute.");
+						String result = DriverCommand.callJUnitScript(_script);
+						Logging.LogTestSuccess("SeleniumPlus Execute Script Succeed.", result);
+					}catch(SAFSException | ClassNotFoundException e){
+						Logging.LogTestFailure("SeleniumPlus Execute Script Failed.", StringUtils.debugmsg(e));
+					}
 				}
 			}
 		}catch(Throwable x){

--- a/src/org/safs/selenium/webdriver/SeleniumPlus.java
+++ b/src/org/safs/selenium/webdriver/SeleniumPlus.java
@@ -60,6 +60,7 @@ package org.safs.selenium.webdriver;
  *  <br>   MAR 31, 2016    (SBJLWA) Add IsComponentExists(), OnGUIXXXBlockID().
  *                                  Modify testStatusCode(): the status code BRANCH_TO_BLOCKID will be considered successful execution.
  *  <br>   APR 19, 2016    (SBJLWA) Modify comments/examples for Click() CtrlClick() ShiftClick() etc.: Handle the optional parameter 'autoscroll'.
+ *  <br>   MAY 17, 2016    (CANAGL) Add support for -junit:classname command-line parameter.
  */
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -204,11 +205,11 @@ public abstract class SeleniumPlus {
 	 * @see EmbeddedHookDriverRunner#autorun(String[]) */
 	public static final String ARG_AUTORUN = "-autorun";
 	
-	/** "-script:" <br>
-	 * command-line argument to invoke a 3rd party script instead of a SeleniumPlus subclass.<br>
-	 * Example: -script:src/com/sas/spock/tests/SpockExperiment.groovy
+	/** "-junit:" <br>
+	 * command-line argument to invoke a JUnit class instead of a SeleniumPlus subclass.<br>
+	 * Example: -junit:com.sas.spock.tests.SpockExperiment
 	 */
-	public static final String ARG_SCRIPT = "-script:";
+	public static final String ARG_JUNIT = "-junit:";
 	
 	/**
 	 * "-class", the parameter to indicate the class name to run test automatically.<br>
@@ -254,7 +255,7 @@ public abstract class SeleniumPlus {
 	private static boolean _autorunClassProvided = false;
 	
 	protected static boolean _isSPC = false;
-	protected static String _script = null;
+	protected static String _junit = null; //classname(s) to execute from -junit: command-line option
 
 	/** 
 	 * Internal framework use only.
@@ -10488,13 +10489,13 @@ public abstract class SeleniumPlus {
 					System.out.println(msg);
 					IndependantLog.info(msg);
 				}
-			}else if(arg.startsWith(ARG_SCRIPT)){
+			}else if(arg.startsWith(ARG_JUNIT)){
 				String msg = null;
 				try{
 					String varg = arg.substring(arg.indexOf(":")+1);//string before the first :
-					msg = "Command-Line script '"+ varg +"' detected.";
-					if(varg.length() > 0) _script = varg;
-					else throw new IllegalArgumentException("-script:path command-line argument malformed.");
+					msg = "Command-Line -junit '"+ varg +"' detected.";
+					if(varg.length() > 0) _junit = varg;
+					else throw new IllegalArgumentException("-junit:class argument malformed.");
 					System.out.println(msg);
 					IndependantLog.info(msg);
 				}catch(Throwable t){
@@ -10565,6 +10566,10 @@ public abstract class SeleniumPlus {
 	 * -autorunclass -- followed by the class that is requesting the automatic configuration and execution, only take effect when paraemter '-autorun' is present.
 	 * <ul>-autorunclass autorun.full.classname</ul>
 	 * <p>
+	 * -junit:classname -- perform a JUnit test instead of executing runTest() in the SeleniumPlus subclass.<br>
+	 * The normal SeleniumPlus bootstrap process and initialization is performed prior to executing the JUnit test.
+	 * <ul>-junit:com.sas.spock.tests.SpockExperiment</ul>
+	 * <p>
 	 * @see org.safs.model.annotations.AutoConfigureJSAFS
 	 * @see org.safs.model.annotations.JSAFSBefore
 	 * @see org.safs.model.annotations.JSAFSAfter
@@ -10601,10 +10606,10 @@ public abstract class SeleniumPlus {
 			if(args.length > 0) _processArgs(args);
 
 			// enable the ability to run 3rd party scripts like Spock/Groovy
-			if(test == null && _script == null) 
+			if(test == null && _junit == null) 
 				throw (cce != null) ? cce :
 				new ClassCastException(theClass + " is not a subclass of SeleniumPlus"+
-				                                  " and no alternative -script was provided.");
+				                                  " and no alternative -junit arg was provided.");
 			
 			if(!_isSPC) {
 				ArrayList<String> altPackages = new ArrayList<String>();
@@ -10622,20 +10627,20 @@ public abstract class SeleniumPlus {
 				String[] adjustedArgs = args;
 				if(!_autorunClassProvided) adjustedArgs = combineParams(args, ARG_AUTORUN_CLASS, theClass);
 				test.autorun(adjustedArgs);
-			}else if(_script==null){
+			}else if(_junit==null){
 				test.runTest();
 			}else {
-				String badpath = "-script command-parameter did not provide a valid script path!";
-				if(_script.length() == 0){
+				String badpath = "-junit command-parameter did not provide a valid classname!";
+				if(_junit.length() == 0){
 					// TODO
-					System.out.println(badpath+" No filepath.");
+					System.out.println(badpath+" No Class.");
 				}else{
 					try{
-						System.out.println("SeleniumPlus -script '"+ _script +"' will now execute.");
-						String result = DriverCommand.callJUnitScript(_script);
-						Logging.LogTestSuccess("SeleniumPlus Execute Script Succeed.", result);
+						System.out.println("SeleniumPlus JUnit '"+ _junit +"' will now execute.");
+						String result = DriverCommand.callJUnitScript(_junit);
+						Logging.LogTestSuccess("SeleniumPlus Execute JUnit Succeeded.", result);
 					}catch(SAFSException | ClassNotFoundException e){
-						Logging.LogTestFailure("SeleniumPlus Execute Script Failed.", StringUtils.debugmsg(e));
+						Logging.LogTestFailure("SeleniumPlus Execute JUnit Failed.", StringUtils.debugmsg(e));
 					}
 				}
 			}

--- a/src/org/safs/selenium/webdriver/SeleniumPlus.java
+++ b/src/org/safs/selenium/webdriver/SeleniumPlus.java
@@ -76,7 +76,6 @@ import org.openqa.selenium.WebDriver.Timeouts;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.SessionNotFoundException;
 import org.safs.ComponentFunction;
-import org.safs.DriverCommand;
 import org.safs.IndependantLog;
 import org.safs.JavaHook;
 import org.safs.Processor;
@@ -10637,8 +10636,8 @@ public abstract class SeleniumPlus {
 				}else{
 					try{
 						System.out.println("SeleniumPlus JUnit '"+ _junit +"' will now execute.");
-						String result = DriverCommand.callJUnitScript(_junit);
-						Logging.LogTestSuccess("SeleniumPlus Execute JUnit Succeeded.", result);
+						//TODO Hard coded command "CallJUnit" will be replaced by constant
+						Runner.command("CallJUnit", _junit);
 					}catch(SAFSException | ClassNotFoundException e){
 						Logging.LogTestFailure("SeleniumPlus Execute JUnit Failed.", StringUtils.debugmsg(e));
 					}

--- a/src/org/safs/tools/drivers/DriverConstant.java
+++ b/src/org/safs/tools/drivers/DriverConstant.java
@@ -12,6 +12,7 @@ import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 
 import org.safs.JavaConstant;
+import org.safs.StatusCodes;
 import org.safs.StringUtils;
 import org.safs.logging.AbstractLogFacility;
 
@@ -54,38 +55,38 @@ public class DriverConstant extends JavaConstant{
 	public static final String RECTYPE_S = "S";
 
 	/** "-2". A warning occurred.**/
-    public static final int STATUS_SCRIPT_WARNING           = -2;      //for scripts AND test tables
+    public static final int STATUS_SCRIPT_WARNING           = StatusCodes.SCRIPT_WARNING;      //for scripts AND test tables
 
 	/** "-1". No known error or warning occurred.**/
-    public static final int STATUS_NO_SCRIPT_FAILURE        = -1;      //for scripts AND test tables
+    public static final int STATUS_NO_SCRIPT_FAILURE        = StatusCodes.NO_SCRIPT_FAILURE;      //for scripts AND test tables
 
 	/** "0". An error occurred.**/
-    public static final int STATUS_GENERAL_SCRIPT_FAILURE   = 0;       //for scripts AND test tables
+    public static final int STATUS_GENERAL_SCRIPT_FAILURE   = StatusCodes.GENERAL_SCRIPT_FAILURE;       //for scripts AND test tables
 
 	/** "2". An IO (file/input) error occurred.**/
-    public static final int STATUS_INVALID_FILE_IO          = 2;
+    public static final int STATUS_INVALID_FILE_IO          = StatusCodes.INVALID_FILE_IO;
 
 	/** "4". No processing has occurred.
 	 * This generally means an engine or driver has not accepted responsibility 
 	 * for the record.  Noone has tried to execute it yet.
 	 */
-    public static final int STATUS_SCRIPT_NOT_EXECUTED      = 4;       //for scripts AND test tables
+    public static final int STATUS_SCRIPT_NOT_EXECUTED      = StatusCodes.SCRIPT_NOT_EXECUTED;       //for scripts AND test tables
 
 	/** "8". An  EXIT TABLE Driver Command flags premature termination.**/
-    public static final int STATUS_EXIT_TABLE_COMMAND       = 8;
+    public static final int STATUS_EXIT_TABLE_COMMAND       = StatusCodes.EXIT_TABLE_COMMAND;
 
 	/** "16". IGNORE this status code. 
 	 * Another process has handled 'stuff'.  
 	 * Generally, a Driver Command will have set this if it already handled all 
 	 * necessary activities like incrementing counters, etc...
 	 */
-    public static final int STATUS_IGNORE_RETURN_CODE       = 16;      //drivers ignore this one
+    public static final int STATUS_IGNORE_RETURN_CODE       = StatusCodes.IGNORE_RETURN_CODE;      //drivers ignore this one
 
     /** "256". BRANCH TO BLOCKID. 
 	 * Used by Driver Command to denote that branching is expected.
 	 * added 11.15.2005 (bolawl) RJL
 	 */
-    public static final int STATUS_BRANCH_TO_BLOCKID       = 256; 
+    public static final int STATUS_BRANCH_TO_BLOCKID       = StatusCodes.BRANCH_TO_BLOCKID; 
     
 	/** "5". User-Defined TEST FAILURE pre-logged. 
 	 * The driver should increment the appropriate counters.

--- a/src/org/safs/tools/engines/TIDDriverCommands.java
+++ b/src/org/safs/tools/engines/TIDDriverCommands.java
@@ -17,6 +17,7 @@
  * JUN 09, 2015  DHARMESH4  Added result email support.
  * SEP 24, 2015  LeiWang	Modify sendEMail(): get more parameters from configuration file to initialize Mailer.
  * MAY 05, 2016 (LeiWang) 	Fix the disorder problem of attachment.
+ * MAY 18, 2016 (LeiWang) 	Implement the keyword 'CallJUnit'.
  */
 package org.safs.tools.engines;
 
@@ -35,6 +36,9 @@ import java.util.Map;
 import javax.mail.Message;
 import javax.mail.internet.ParseException;
 
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
 import org.safs.IndependantLog;
 import org.safs.Log;
 import org.safs.SAFSException;
@@ -42,6 +46,7 @@ import org.safs.SAFSNullPointerException;
 import org.safs.STAFHelper;
 import org.safs.StatusCodes;
 import org.safs.StringUtils;
+import org.safs.TestRecordData;
 import org.safs.TestRecordHelper;
 import org.safs.image.ImageUtils;
 import org.safs.logging.AbstractLogFacility;
@@ -164,6 +169,9 @@ public class TIDDriverCommands extends GenericEngine {
 	public static final String COMMAND_SETIMAGEDEBUG                 = "SetImageDebug";
 	/** "SetImageFuzzyMatching" */
 	public static final String COMMAND_SETIMAGEFUZZYMATCHING         = "SetImageFuzzyMatching";
+	
+	/** "CallJUnit" */
+	private static final String COMMAND_CALLJUNIT			         = "CallJUnit";
 	
 	public static final String SET_MILLIS_BETWEEN_RECORDS	 		= "SetMillisBetweenRecords";//AbstractDriver.millisBetweenRecords
 	public static final String GET_MILLIS_BETWEEN_RECORDS	 		= "GetMillisBetweenRecords";//AbstractDriver.millisBetweenRecords
@@ -346,7 +354,10 @@ public class TIDDriverCommands extends GenericEngine {
 				return takeScreenShot();
 			}else if (command.equalsIgnoreCase(COMMAND_SENDEMAIL)){
 				return sendEmail();
+			}else if (command.equalsIgnoreCase(COMMAND_CALLJUNIT)){
+				return callJUnit();
 			}
+		    
 		    rc = dcLog.processRecord(this.testRecordData);
 			if (rc == DriverConstant.STATUS_SCRIPT_NOT_EXECUTED) rc = dcFlow.processRecord(this.testRecordData);
 			if (rc == DriverConstant.STATUS_SCRIPT_NOT_EXECUTED) rc = dcCounters.processRecord(this.testRecordData);
@@ -1175,6 +1186,109 @@ public class TIDDriverCommands extends GenericEngine {
 		  
 		  simpleSuccessMessage(testRecordData, command, message);
 		  return setTRDStatus(testRecordData, DriverConstant.STATUS_NO_SCRIPT_FAILURE);
+	  }
+	  
+	  /**
+	   * Execute a JUnit test.
+	   * @param classname	String, the 'JUnit test class' name to be executed.
+	   * @return String, the JUnit test result
+	   * @throws ClassNotFoundException if the 'JUnit test class' can be found.
+	   * @throws SAFSException if the 'JUnit execution' return null.
+	   */
+	  public static String callJUnit(String classname) throws ClassNotFoundException, SAFSException{
+		  String debugmsg = StringUtils.debugmsg(false);
+
+		  JUnitCore junit = new JUnitCore();
+		  Result jresult = junit.run(Class.forName(classname));
+
+		  if(jresult == null){
+			  String detail = "JUnitCore executed '"+classname+"', and returned a null Result!";
+			  throw new SAFSException(detail);
+		  }else{
+			  StringBuffer sb = new StringBuffer();
+			  sb.append(jresult.getRunCount()+ " tests run.\n");
+			  sb.append(jresult.getIgnoreCount()+" tests ignored.\n");
+			  sb.append(jresult.getFailureCount()+ " tests failed.\n");
+			  sb.append("Runtime: "+ jresult.getRunTime() +" milliseconds.\n");
+			  List<Failure> failures = jresult.getFailures();
+			  sb.append("");
+			  for(Failure failure:failures){
+				  sb.append("   "+ failure.toString()+"\n");
+				  sb.append("\n");
+			  }
+			  IndependantLog.debug(debugmsg+" succeeded with result:\n "+sb.toString());
+			  return sb.toString();
+		  }   
+	  }
+	  
+	  /**
+	   * Handle the CallJUnit Keyword.<br>
+	   * 
+	   * C, CallJUnit, package.p1.class;package.p2.class<br>
+	   * 
+	   * @return long, the execution status code.
+	   * @throws SAFSException if the 'JUnit execution' return null
+	   */
+	  private long callJUnit() throws SAFSException{
+
+		  String debugmsg = StringUtils.debugmsg(false);
+		  String classnames = null;
+		  //get the JUnit test class names, it could be semi-colon separated string, like package.p1.class;package.p2.class;
+		  try{ classnames = testRecordData.getTrimmedUnquotedInputRecordToken(2);}
+		  catch(SAFSNullPointerException | IndexOutOfBoundsException e){;}
+
+		  if (!StringUtils.isValid(classnames)){
+			  message = failedText.convert("bad_param", "Invalid parameter value for ClassNames", "ClassNames");
+			  standardErrorMessage(testRecordData, message, testRecordData.getInputRecord());
+			  return setTRDStatus(testRecordData, DriverConstant.STATUS_GENERAL_SCRIPT_FAILURE);
+		  }
+
+		  testRecordData.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
+		  IndependantLog.info(debugmsg+"............................. handling [JUnit]: "+classnames);
+
+		  //CACHE TestRecordData. Within callJUnit() if we call some SAFS/SE+/JSAFS test, the field testRecordData
+		  //might get changed, we need to cache it. Then after calling of callJUnit(), we set it back.
+		  TestRecordData cachedData = new TestRecordHelper();
+		  testRecordData.copyData(cachedData);
+
+		  String[] clazzes = classnames.split(StringUtils.SEMI_COLON);
+
+		  boolean withWarning = false;
+		  StringBuffer result = new StringBuffer();
+		  for(String clazz:clazzes){
+			  if(!StringUtils.isValid(clazz)){
+				  IndependantLog.warn(debugmsg+" the class name '+clazz+' is not valid!");
+				  continue;
+			  }
+			  result.append("---------------------------------  '"+clazz+"' Execution Result: -----------------------------------\n");
+			  try {
+				  result.append(callJUnit(clazz));
+			  } catch (ClassNotFoundException e) {
+				  //This will be considered as a warning.
+				  withWarning = true;
+				  String msg = "'"+clazz+"' was not executed! Due to "+StringUtils.debugmsg(e);
+				  IndependantLog.warn(debugmsg+msg);
+				  result.append(msg);
+			  } 
+		  }
+
+		  //Set CACHED TestRecordData back.
+		  cachedData.copyData(testRecordData);
+		  command = testRecordData.getCommand();
+
+		  //Set the JUnit test result to the test record's status for future use.
+		  testRecordData.setStatusInfo(result.toString());
+
+		  if(withWarning){
+			  String message = genericText.convert("standard_warn", command+" warning in table "+testRecordData.getFilename()+" at line "+testRecordData.getLineNumber()+".", command, classnames);
+			  logMessage(message, result.toString(), AbstractLogFacility.WARNING_MESSAGE);
+			  return setTRDStatus(testRecordData, DriverConstant.STATUS_SCRIPT_WARNING);
+		  }else{
+			  String message = genericText.convert("success2", command+" '"+ classnames +"' successful.", command, classnames);
+			  logMessage(message, result.toString(), AbstractLogFacility.GENERIC_MESSAGE);
+			  return setTRDStatus(testRecordData, DriverConstant.STATUS_NO_SCRIPT_FAILURE);
+		  }
+		  
 	  }
 }
 


### PR DESCRIPTION
While originally sought as a means to run Spock/Groovy JUnit tests the implementation is much more generic than that.  It has only a dependency on JUnit Core to run ANY type of JUnit test runnable from JUnitCore.
