### PR TITLE
Moved towards a single DriverInterface for JSAFSDriver and InputProce…

### DIFF
--- a/src/org/safs/cukes/StepDriver.java
+++ b/src/org/safs/cukes/StepDriver.java
@@ -5,6 +5,7 @@ package org.safs.cukes;
 
 import java.util.List;
 
+import org.safs.model.tools.Driver;
 import org.safs.tools.drivers.JSAFSDriver;
 /**
  * Driver-enabled StepDriver allowing Cukes users to use SAFS services and engines 
@@ -67,6 +68,7 @@ public class StepDriver {
 	 */
 	protected static JSAFSDriver initJSAFS() {
 		System.out.println("StepDefinitions has enterd initJSAFS().");
+		Driver.setIDriver(_jsafs);
 		_our_driver = true;	
 		_jsafs.run();
 		_jsafs.systemExitOnShutdown = false;
@@ -97,6 +99,7 @@ public class StepDriver {
 	 */
 	protected static void shutdownJSAFS() throws Exception {
 		if(allowShutdown()){	
+			Driver.setIDriver(null);
 			jsafs().shutdown();
 		}else{
 			if(!_our_driver)

--- a/src/org/safs/model/annotations/Utilities.java
+++ b/src/org/safs/model/annotations/Utilities.java
@@ -534,7 +534,7 @@ public class Utilities {
 				if( object instanceof RuntimeDataAware && 
 						store instanceof Runner){
 						debug("AutoConfigure injecting the RuntimeDataInterface into Class instance "+ c.getName()+" ...");
-						((RuntimeDataAware)object).setRuntimeDataInterface((RuntimeDataInterface) ((Runner)store).jsafs().getCoreInterface());
+						((RuntimeDataAware)object).setRuntimeDataInterface((RuntimeDataInterface) ((Runner)store).driver().iDriver().getCoreInterface());
 				}
 				
 				//According to

--- a/src/org/safs/model/examples/advanced/EmbeddedJSAFSDriver.java
+++ b/src/org/safs/model/examples/advanced/EmbeddedJSAFSDriver.java
@@ -11,6 +11,7 @@ import org.safs.model.commands.GenericObjectFunctions;
 import org.safs.model.components.EditBox;
 import org.safs.model.components.PushButton;
 import org.safs.model.components.Window;
+import org.safs.model.tools.Driver;
 import org.safs.tools.drivers.DefaultDriver;
 import org.safs.tools.drivers.JSAFSDriver;
 import org.safs.Log;
@@ -115,6 +116,10 @@ public class EmbeddedJSAFSDriver {
 	 */
 	public JSAFSDriver jsafs = new JSAFSDriver("Driver");
 	
+	public EmbeddedJSAFSDriver(){
+		Driver.setIDriver(jsafs);
+	}
+	
 	/**
 	 * Possible main entry point for the test class.
 	 * The JVM should be instanced with required -D Property settings used by this example:
@@ -187,7 +192,6 @@ public class EmbeddedJSAFSDriver {
 	 * In this example this is the final call before JSAFSDriver and all of SAFS is shutdown.
 	 */
 	private void cleanupTests() {
-		// TODO Auto-generated method stub
-		
+		Driver.setIDriver(null);
 	}
 }

--- a/src/org/safs/model/examples/advanced/JSAFSAdvancedRuntime.java
+++ b/src/org/safs/model/examples/advanced/JSAFSAdvancedRuntime.java
@@ -1,8 +1,5 @@
 package org.safs.model.examples.advanced;
 
-import java.util.Enumeration;
-import java.util.Vector;
-
 import javax.swing.JOptionPane;
 
 import org.safs.JavaHook;
@@ -14,8 +11,6 @@ import org.safs.model.commands.DDDriverCommands;
 import org.safs.model.commands.GenericMasterFunctions;
 import org.safs.text.FAILStrings;
 import org.safs.text.GENStrings;
-import org.safs.tools.UniqueStringID;
-import org.safs.tools.counters.CountersInterface;
 import org.safs.tools.drivers.AbstractDriver;
 import org.safs.tools.drivers.ConfigureInterface;
 import org.safs.tools.drivers.DefaultDriver;
@@ -26,13 +21,9 @@ import org.safs.tools.engines.SAFSROBOTJ;
 import org.safs.tools.engines.TIDComponent;
 import org.safs.tools.engines.TIDDriverCommands;
 import org.safs.tools.engines.SAFSDRIVERCOMMANDS;
-import org.safs.tools.input.InputInterface;
 import org.safs.tools.input.MapsInterface;
-import org.safs.tools.input.UniqueStringFileInfo;
 import org.safs.tools.input.UniqueStringItemInfo;
-import org.safs.tools.input.UniqueStringMapInfo;
 import org.safs.tools.logs.LogsInterface;
-import org.safs.tools.logs.UniqueStringMessageInfo;
 import org.safs.tools.vars.VarsInterface;
 import org.safs.tools.status.StatusCounter;
 import org.safs.tools.status.StatusInterface;
@@ -182,32 +173,6 @@ public class JSAFSAdvancedRuntime extends DefaultDriver {
 	protected void validateTestParameters(){
 		//test table data validation not required
 	}
-	
-	/**
-	 * Convenience routine to log different message types to the active log.
-	 *  
-	 * (We probably should "fix" the LogsInterface and the implementations 
-	 * to eliminate the need for this convenience routine!)
-	 *  
-	 * @param message String message
-	 * @param description String (optional) for more detailed info.  Can be null.
-	 * @param type int message type constant from AbstractLogFacility.
-	 * <p>  
-	 * Some Message Types:<br/>
-	 * <ul>
-	 * <li>{@link AbstractLogFacility#GENERIC_MESSAGE}
-	 * <li>{@link AbstractLogFacility#PASSED_MESSAGE}
-	 * <li>{@link AbstractLogFacility#FAILED_MESSAGE}
-	 * <li>{@link AbstractLogFacility#FAILED_OK_MESSAGE}
-	 * <li>{@link AbstractLogFacility#WARNING_MESSAGE}
-	 * <li>{@link AbstractLogFacility#WARNING_OK_MESSAGE}
-	 *</ul>
-	 *@see LogsInterface#logMessage(org.safs.tools.logs.UniqueMessageInterface) 
-	 */
-	protected void logMessage(String message, String description, int type){
-		logs.logMessage(new UniqueStringMessageInfo(cycleLog.getStringID(), message, description, type));
-	}
-	
 	
 	/**
 	 * Convienience (re)initializer for a TestRecordHelper.

--- a/src/org/safs/model/tools/AbstractDriver.java
+++ b/src/org/safs/model/tools/AbstractDriver.java
@@ -395,13 +395,16 @@ public abstract class AbstractDriver {
 		    trd = processor().initTestRecordData(
 		    		model.exportTestRecord(processor().getDefaultSeparator()), 
 		    		processor().getDefaultSeparator());
-		    processor().checkTestLevelForStepExecution();
-			trd.setCommand(command);
-			trd.setWindowName(parent);
-			trd.setCompName(child);
-			trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
-			long result = processor().processTestRecord(trd);
-			processor().resetTestLevel();
+		    try{
+			    processor().checkTestLevelForStepExecution();
+				trd.setCommand(command);
+				trd.setWindowName(parent);
+				trd.setCompName(child);
+				trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
+				long result = processor().processTestRecord(trd);
+		    }finally{
+				processor().resetTestLevel();		    	
+		    }
 			return trd;
 		}
 	}	

--- a/src/org/safs/model/tools/AbstractDriver.java
+++ b/src/org/safs/model/tools/AbstractDriver.java
@@ -395,11 +395,13 @@ public abstract class AbstractDriver {
 		    trd = processor().initTestRecordData(
 		    		model.exportTestRecord(processor().getDefaultSeparator()), 
 		    		processor().getDefaultSeparator());
+		    processor().checkTestLevelForStepExecution();
 			trd.setCommand(command);
 			trd.setWindowName(parent);
 			trd.setCompName(child);
 			trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
 			long result = processor().processTestRecord(trd);
+			processor().resetTestLevel();
 			return trd;
 		}
 	}	

--- a/src/org/safs/model/tools/AbstractDriver.java
+++ b/src/org/safs/model/tools/AbstractDriver.java
@@ -20,6 +20,8 @@ import org.safs.model.commands.DDDriverCommands;
 import org.safs.text.FileUtilities;
 import org.safs.tools.CaseInsensitiveFile;
 import org.safs.tools.drivers.DriverConstant;
+import org.safs.tools.drivers.DriverInterface;
+import org.safs.tools.drivers.InputProcessor;
 import org.safs.tools.drivers.JSAFSDriver;
 
 /**
@@ -71,7 +73,11 @@ public abstract class AbstractDriver {
 		boolean filesarg = false;
 		
 		try{ 
-			dir = jsafs().getDatapoolDir();
+			if(jsafs() != null) { dir = jsafs().getDatapoolDir(); }
+			else{
+				// TODO: Use InputProcessor if JSAFSDriver not present.
+				dir = processor().getDatapoolDir();
+			}
 			filename = DEFAULT_APPMAP_ORDER;
 			String jvmarg = null;
 			jvmarg = System.getProperty(APPMAP_ORDER_PROPERTY);
@@ -165,11 +171,35 @@ public abstract class AbstractDriver {
 	 * Otherwise this method will do nothing, just return the original expression string.
 	 */
 	protected String processExpression(String expression){
-		return jsafs().processExpression(expression);//Expression will turn off/on both "math" and "DDVariable"
-//		return jsafs().resolveExpression(expression);//Expression will turn off/on "math", while "DDVariable" will be kept all the time
+		if(jsafs() != null){ 
+			return jsafs().processExpression(expression);//Expression will turn off/on both "math" and "DDVariable" 
+			//return jsafs().resolveExpression(expression);//Expression will turn off/on "math", while "DDVariable" will be kept all the time
+		}else{
+			// TODO: Use InputProcessor if JSAFSDriver not present.
+			String sep = processor().getTestRecordData().getSeparator();
+			String exp = processor().getVarsInterface().resolveExpressions(expression, sep);
+			// LeiWang: should we always remove the wrapping double-quote? If the original expression is double-quoted, then we should not remove them.
+			return StringUtils.removeWrappingDoubleQuotes(exp);
+		}
 	}
-	
+
 	protected abstract JSAFSDriver jsafs();	
+	protected abstract InputProcessor processor();
+	
+	/**
+	 * @return DriverInterface currently being used.<br>
+	 * Could be a JSAFSDriver.  Could be an InputProcessor.<br>
+	 * Subclasses should override to support other DriverInterface instances not tracked in this superclass.  
+	 * Can be null if none are set.
+	 * @see #setIDriver(DriverInterface)
+	 * @see JSAFSDriver
+	 * @see InputProcessor
+	 */
+	public DriverInterface iDriver(){
+		if(jsafs() instanceof DriverInterface) return jsafs();
+		if(processor() instanceof DriverInterface) return processor();
+		return null;
+	}
 	
 	/**
 	 * Turn ON Expressions, AppMapChaining, and AppMapResolve.
@@ -278,17 +308,40 @@ public abstract class AbstractDriver {
 		if(parameters instanceof String[] && parameters.length > 0) 
 			model.addParameters(parameters);
 		
-		String sep = StringUtils.getUniqueSep(jsafs().SEPARATOR, command, parameters);
+		String sep = null;
+		try{
+			sep = StringUtils.getUniqueSep(jsafs().SEPARATOR, command, parameters);
+		}catch(NullPointerException np){
+			// TODO: Use InputProcessor if JSAFSDriver not present.
+			sep = StringUtils.getUniqueSep(processor().getDefaultSeparator(), command, parameters);
+		}
+		TestRecordHelper trd = null;
 		if(sep==null){
-			TestRecordHelper trd = jsafs().initTestRecordData(null);
-			trd.setRecordType(DriverConstant.RECTYPE_C);
+			if(jsafs() != null){ 
+				trd = jsafs().initTestRecordData(null);
+				trd.setRecordType(DriverConstant.RECTYPE_C);
+				trd.setSeparator(jsafs().SEPARATOR);
+				trd.setInputRecord(model.exportTestRecord(jsafs().SEPARATOR));
+			}else{
+			    trd = processor().initTestRecordData(
+			    		model.exportTestRecord(processor().getDefaultSeparator()), 
+			    		processor().getDefaultSeparator());
+			}
 			trd.setCommand(command);
-			trd.setInputRecord(model.exportTestRecord(jsafs().SEPARATOR));
 			trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
 			trd.setStatusInfo("Unable to dynamically deduce an acceptable unique SEPARATOR for this Command!");
 			return trd;
 		}
-		return jsafs().runDriverCommand(model, sep);
+		if(jsafs() != null)	return jsafs().runDriverCommand(model, sep);
+		else {
+		    trd = processor().initTestRecordData(
+		    		model.exportTestRecord(processor().getDefaultSeparator()), 
+		    		processor().getDefaultSeparator());
+			trd.setCommand(command);
+			trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
+			long result = processor().processDriverCommand(trd);
+			return trd;
+		}
 	}
 
 	/**
@@ -309,22 +362,45 @@ public abstract class AbstractDriver {
 	 */
 	public TestRecordHelper runComponentFunctionConverted(String command, String child, String parent, String... parameters)throws Throwable{
 		ComponentFunction model = new ComponentFunction(command, parent, child);
-		String sep = StringUtils.getUniqueSep(jsafs().SEPARATOR, command+child+parent, parameters);
+		String sep = null;
+		try{ sep = StringUtils.getUniqueSep(jsafs().SEPARATOR, command+child+parent, parameters);}
+		catch(NullPointerException np){
+			// TODO: Use InputProcessor if JSAFSDriver not present.
+			sep = StringUtils.getUniqueSep(processor().getDefaultSeparator(), command+child+parent, parameters);
+		}
 		if(parameters instanceof String[]&& parameters.length > 0) 
 			model.addParameters(parameters);
-		
+
+		TestRecordHelper trd = null;
 		if(sep==null){
-			TestRecordHelper trd = jsafs().initTestRecordData(null);
-			trd.setRecordType(DriverConstant.RECTYPE_T);
+			if(jsafs() instanceof JSAFSDriver){
+				trd = jsafs().initTestRecordData(null);
+				trd.setRecordType(DriverConstant.RECTYPE_T);
+				trd.setSeparator(jsafs().SEPARATOR);
+				trd.setInputRecord(model.exportTestRecord(jsafs().SEPARATOR));
+			}else{
+			    trd = processor().initTestRecordData(
+			    		model.exportTestRecord(processor().getDefaultSeparator()), 
+			    		processor().getDefaultSeparator());
+			}
 			trd.setCommand(command);
 			trd.setWindowName(parent);
 			trd.setCompName(child);
-			trd.setInputRecord(model.exportTestRecord(jsafs().SEPARATOR));
 			trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
 			trd.setStatusInfo("Unable to dynamically deduce an acceptable unique SEPARATOR for this Action!");
 			return trd;
 		}
-		return jsafs().runComponentFunction(model, sep);
-	}
-	
+		if(jsafs() != null)	return jsafs().runComponentFunction(model, sep);
+		else {
+		    trd = processor().initTestRecordData(
+		    		model.exportTestRecord(processor().getDefaultSeparator()), 
+		    		processor().getDefaultSeparator());
+			trd.setCommand(command);
+			trd.setWindowName(parent);
+			trd.setCompName(child);
+			trd.setStatusCode(StatusCodes.SCRIPT_NOT_EXECUTED);
+			long result = processor().processTestRecord(trd);
+			return trd;
+		}
+	}	
 }

--- a/src/org/safs/model/tools/EmbeddedHookDriverDriver.java
+++ b/src/org/safs/model/tools/EmbeddedHookDriverDriver.java
@@ -20,6 +20,7 @@ import org.safs.model.ComponentFunction;
 import org.safs.model.DriverCommand;
 import org.safs.tools.drivers.DriverConstant;
 import org.safs.tools.drivers.EmbeddedHookDriver;
+import org.safs.tools.drivers.InputProcessor;
 import org.safs.tools.drivers.JSAFSDriver;
 
 /**
@@ -63,7 +64,13 @@ public class EmbeddedHookDriverDriver extends AbstractDriver{
 		}
 	}
 
+	/** Provided by our internal EmbeddedHookDriver.
+	 * @see EmbeddedHookDriver */
+	@Override
 	protected JSAFSDriver jsafs(){ return driver.jsafs();}
+	/** Does not support storing or using an InputProcessor internally. */
+	@Override
+	protected InputProcessor processor(){ return null; }
 	
 	/**
 	 * Must be called at least once to initialize the internal Driver.

--- a/src/org/safs/model/tools/EmbeddedHookDriverRunner.java
+++ b/src/org/safs/model/tools/EmbeddedHookDriverRunner.java
@@ -187,7 +187,7 @@ public class EmbeddedHookDriverRunner implements JSAFSConfiguredClassStore{
 	
 	public TestRecordHelper action(String command, String window, String component, String... params) throws Throwable{
 		TestRecordHelper rc = driver.runComponentFunction(command, component, window, params);
-		jsafs().incrementTestStatus(rc.getStatusCode());
+		driver.iDriver().incrementTestStatus(rc.getStatusCode());
 		if(rc.getStatusCode()==StatusCodes.SCRIPT_NOT_EXECUTED){
 			jsafs().logMessage(component +" "+command.toUpperCase() +" did NOT execute!", 
 				    "Support for this action may not be available in this runtime environment.", 
@@ -198,7 +198,7 @@ public class EmbeddedHookDriverRunner implements JSAFSConfiguredClassStore{
 	
 	public TestRecordHelper command(String command, String... params) throws Throwable{
 		TestRecordHelper rc = driver.runDriverCommand(command, params);
-		jsafs().incrementTestStatus(rc.getStatusCode());
+		driver.iDriver().incrementTestStatus(rc.getStatusCode());
 		if(rc.getStatusCode()==StatusCodes.SCRIPT_NOT_EXECUTED){
 			jsafs().logMessage(command.toUpperCase() +" did NOT execute!", 
 				    "Support for this command may not be available in this runtime environment.", 

--- a/src/org/safs/selenium/spc/WDSPC.java
+++ b/src/org/safs/selenium/spc/WDSPC.java
@@ -1,37 +1,18 @@
 package org.safs.selenium.spc;
 
-import java.awt.AWTException;
-import java.awt.Color;
-import java.awt.Rectangle;
-import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Properties;
-
 import javax.imageio.ImageIO;
-import javax.swing.JOptionPane;
-
 import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriver.TargetLocator;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.server.RemoteControlConfiguration;
-import org.safs.IndependantLog;
 import org.safs.Log;
 import org.safs.SAFSException;
-import org.safs.StatusCodes;
-import org.safs.selenium.DocumentParser;
 import org.safs.selenium.SGuiObject;
-import org.safs.selenium.SeleniumGUIUtilities;
-import org.safs.selenium.SeleniumJavaHook;
-import org.safs.selenium.util.HtmlFrameComp;
-import org.safs.selenium.util.JavaScriptFunctions;
 import org.safs.selenium.webdriver.EmbeddedSeleniumHookDriver;
 import org.safs.selenium.webdriver.SeleniumHook;
 import org.safs.selenium.webdriver.SeleniumPlus;
@@ -41,13 +22,6 @@ import org.safs.selenium.webdriver.lib.RemoteDriver.SessionInfo;
 import org.safs.selenium.webdriver.lib.SearchObject;
 import org.safs.selenium.webdriver.lib.SeleniumPlusException;
 import org.safs.selenium.webdriver.lib.WDLibrary;
-import org.safs.text.GENKEYS;
-import org.safs.tools.drivers.EmbeddedHookDriver;
-
-import com.gargoylesoftware.htmlunit.util.StringUtils;
-import com.thoughtworks.selenium.DefaultSelenium;
-import com.thoughtworks.selenium.Selenium;
-import com.thoughtworks.selenium.SeleniumException;
 
 /**
  * 
@@ -131,7 +105,7 @@ public class WDSPC extends SeleniumPlus{
 			if(USE_REMOTE){
 				Log.info("WDSPC attempting to (re)start RemoteServer.");
 				//if(WebDriverGUIUtilities.startRemoteServer()){
-				if(WebDriverGUIUtilities.startRemoteServer(Runner.jsafs().getProjectRootDir())){
+				if(WebDriverGUIUtilities.startRemoteServer(Runner.driver().iDriver().getProjectRootDir())){
 					try{
 						WDLibrary.startBrowser(browser, url, id, BROWSER_TIMEOUT, USE_REMOTE, BROWSER_PARMS);
 					}catch(Throwable th2){

--- a/src/org/safs/selenium/webdriver/SeleniumPlus.java
+++ b/src/org/safs/selenium/webdriver/SeleniumPlus.java
@@ -3370,7 +3370,7 @@ public abstract class SeleniumPlus {
 		
 		private static void incrementCounters(boolean wasSuccessful){
 			long status = wasSuccessful ? CountersInterface.STATUS_TEST_PASS : CountersInterface.STATUS_TEST_FAILURE;
-			Runner.jsafs().getCountersInterface().incrementAllCounters(new UniqueStringCounterInfo("STEP", "STEP"), status);
+			Runner.driver().iDriver().getCountersInterface().incrementAllCounters(new UniqueStringCounterInfo("STEP", "STEP"), status);
 		}
 		
 		/** 

--- a/src/org/safs/tools/drivers/AbstractInputProcessor.java
+++ b/src/org/safs/tools/drivers/AbstractInputProcessor.java
@@ -4,13 +4,12 @@
 package org.safs.tools.drivers;
 
 import java.util.ListIterator;
-import java.util.Locale;
-import org.safs.GetText;
+import org.safs.StatusCodes;
 import org.safs.TestRecordData;
 import org.safs.TestRecordHelper;
 import org.safs.DCTestRecordHelper;
-import org.safs.tools.UniqueIDInterface;
 import org.safs.tools.counters.CountersInterface;
+import org.safs.tools.counters.UniqueStringCounterInfo;
 import org.safs.tools.engines.AutoItComponent;
 import org.safs.tools.engines.EngineInterface;
 import org.safs.tools.engines.TIDDriverCommands;
@@ -47,6 +46,8 @@ public abstract class AbstractInputProcessor implements DriverInterface {
 
 	/** Pass/Fail info for a single instance of an Input processor. **/
 	protected StatusCounter    statusCounter = new StatusCounter();
+	
+	protected UniqueStringCounterInfo counterInfo = null;
 	
 	/** Stores input record information for the driver and some engines. **/
 	protected TestRecordHelper testRecordData = new DCTestRecordHelper();
@@ -450,5 +451,74 @@ public abstract class AbstractInputProcessor implements DriverInterface {
 	 */
 	public long setRootVerifyDir(String absolute_path){
 		return driver.setRootVerifyDir(absolute_path);		
+	}
+	/**
+	 * Increment General (not Test) record counts.
+	 * @param status
+	 * @see StatusCodes
+	 */
+	public void incrementGeneralStatus(int status){
+		switch(status){		
+			case StatusCodes.OK:
+				statusCounter.incrementGeneralPasses();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_PASS);
+				break;
+			case StatusCodes.INVALID_FILE_IO:
+				statusCounter.incrementIOFailures();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_IO_FAILURE);
+				break;
+			case StatusCodes.GENERAL_SCRIPT_FAILURE:
+			case StatusCodes.WRONG_NUM_FIELDS:
+				statusCounter.incrementGeneralFailures();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_FAILURE);
+				break;
+			case StatusCodes.SCRIPT_WARNING:
+				statusCounter.incrementGeneralWarnings();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_WARNING);
+				break;
+			case StatusCodes.SCRIPT_NOT_EXECUTED:
+				statusCounter.incrementSkippedRecords();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_SKIPPED_RECORD);
+				break;
+			default:
+				statusCounter.incrementGeneralPasses();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_PASS);
+		}
+	}
+
+	/**
+	 * Increment Test Record counts.
+	 * @param status
+	 * @see StatusCodes
+	 */
+	public void incrementTestStatus(int status){
+		switch(status){		
+			case StatusCodes.OK:
+				statusCounter.incrementTestPasses();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_PASS);
+				break;
+			case StatusCodes.INVALID_FILE_IO:
+				statusCounter.incrementTestIOFailures();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_IO_FAILURE);
+				break;
+			case StatusCodes.GENERAL_SCRIPT_FAILURE:
+			case StatusCodes.WRONG_NUM_FIELDS:
+			case StatusCodes.NO_RECORD_TYPE_FIELD:
+			case StatusCodes.UNRECOGNIZED_RECORD_TYPE:
+				statusCounter.incrementTestFailures();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_FAILURE);
+				break;
+			case StatusCodes.SCRIPT_WARNING:
+				statusCounter.incrementTestWarnings();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_WARNING);
+				break;
+			case StatusCodes.SCRIPT_NOT_EXECUTED:
+				statusCounter.incrementSkippedRecords();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_SKIPPED_RECORD);
+				break;
+			default:
+				statusCounter.incrementGeneralPasses();
+				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_PASS);
+		}
 	}
 }

--- a/src/org/safs/tools/drivers/DriverInterface.java
+++ b/src/org/safs/tools/drivers/DriverInterface.java
@@ -112,5 +112,9 @@ public interface DriverInterface extends PathInterface {
 		
 	public int getMillisBetweenRecords();
 	public void setMillisBetweenRecords(int millisBetweenRecords);
+	
+	public void incrementTestStatus(int status);
+	public void incrementGeneralStatus(int status);
+	public void logMessage(String msg, String desc, int msgType);
 }
 

--- a/src/org/safs/tools/drivers/EmbeddedHookDriver.java
+++ b/src/org/safs/tools/drivers/EmbeddedHookDriver.java
@@ -23,6 +23,7 @@ import org.safs.STAFHelper;
 import org.safs.SingletonSTAFHelper;
 import org.safs.TestRecordHelper;
 import org.safs.logging.LogUtilities;
+import org.safs.model.tools.Driver;
 import org.safs.staf.STAFProcessHelpers;
 import org.safs.tools.counters.UniqueStringCounterInfo;
 import org.safs.tools.status.StatusCounter;
@@ -117,6 +118,7 @@ public class EmbeddedHookDriver extends JavaHook {
 	protected void initialize(){
 		hook = this;
 		jsafs = new JSAFSDriver(process_name);
+		Driver.setIDriver(jsafs);
 		jsafs.systemExitOnShutdown = false;
 		jsafs.removeShutdownHook();
 	}
@@ -549,6 +551,7 @@ public class EmbeddedHookDriver extends JavaHook {
 		  }
 		  Log.info("EmbeddedDriver shutting down embedded JSAFSDriver...");
 		  try{
+			  Driver.setIDriver(null);
 			  jsafs.shutdown();
 		  }catch(NullPointerException x){
 			  Log.debug("EmbeddedDriver JSAFS shutdown "+x.getClass().getSimpleName()+": "+x.getMessage(), x);

--- a/src/org/safs/tools/drivers/InputProcessor.java
+++ b/src/org/safs/tools/drivers/InputProcessor.java
@@ -82,7 +82,45 @@ public class InputProcessor extends AbstractInputProcessor {
 		if (isSuite) activeTableVar = "safsActiveSuite";
 		if (isStep) activeTableVar = "safsActiveStep";
 	}
-
+	
+	/**
+	 * <p>
+	 * The current InputProcessor will be set to org.safs.model.tools.Driver, so that it can be used to execute 'test record'
+	 * within Java code. If the 'test record' is 'driver command', there is no problem; while if the 'test record' is 
+	 * 'component function' and the InputProcessor is NOT at Step level, the 'component function' will be treated as 'Switch Suite'/'Switch Step'
+	 * and fail. For example, if InputProcessor is at Cycle level, then "T, Window, Component, VerifyValues, a, b", will be treated to execute Window.STD suite file.
+	 * To avoid this situation, we need to set the field 'isStep' before executing 'component function'.
+	 * This function is for this purpose.
+	 * </p>
+	 * 
+	 * @return boolean, if the private filed {@link #isStep} has been changed.
+	 * 
+	 * @see #processTest()
+	 * @see #resetTestLevel()
+	 * @ee {@link #processTestRecord(TestRecordHelper)}
+	 * @see org.safs.model.tools.AbstractDriver#runComponentFunctionConverted(String, String, String, String...)
+	 */
+	public boolean checkTestLevelForStepExecution(){
+		if(!DriverConstant.DRIVER_STEP_TESTLEVEL.equalsIgnoreCase(getTestLevel())){
+			Log.debug("InputProcessor: Current Test Level is "+getTestLevel()+", 'Step Test Record' cannot be executed! Change private field 'isStep' to true.");
+			isStep = true;
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Reset those private fields about the 'test level'.
+	 * 
+	 * @see #checkTestLevelForStepExecution()
+	 * @see org.safs.model.tools.AbstractDriver#runComponentFunctionConverted(String, String, String, String...)
+	 */
+	public void resetTestLevel(){
+		isCycle = (sourceid.getTestLevel().equalsIgnoreCase(DriverConstant.DRIVER_CYCLE_TESTLEVEL));
+		isSuite = (sourceid.getTestLevel().equalsIgnoreCase(DriverConstant.DRIVER_SUITE_TESTLEVEL));
+		isStep = (sourceid.getTestLevel().equalsIgnoreCase(DriverConstant.DRIVER_STEP_TESTLEVEL));
+	}
+	
 	/***************************************************************************
 	 * Convenience routine for building the appropriate MessageInfo and logging
 	 * a message to our active log.  Consult the AbstractLogFacility for valid 

--- a/src/org/safs/tools/drivers/InputProcessor.java
+++ b/src/org/safs/tools/drivers/InputProcessor.java
@@ -13,6 +13,7 @@ import org.safs.StringUtils;
 import org.safs.TestRecordData;
 import org.safs.TestRecordHelper;
 import org.safs.logging.AbstractLogFacility;
+import org.safs.model.tools.Driver;
 import org.safs.staf.STAFProcessHelpers;
 import org.safs.text.FAILStrings;
 import org.safs.text.GENStrings;
@@ -60,11 +61,6 @@ public class InputProcessor extends AbstractInputProcessor {
 	 */
 	protected UniqueIDInterface logid = null;
 	
-	/**
-	 * The CounterInfo to send to incrementAllCounters.
-	 */
-	protected UniqueStringCounterInfo counterInfo = null;
-	
 	private boolean isCycle = false;
 	private boolean isSuite = false;
 	private boolean isStep  = false;
@@ -94,7 +90,7 @@ public class InputProcessor extends AbstractInputProcessor {
 	 * 
 	 * @see org.safs.logging.AbstractLogFacility 
 	 */
-	protected void logMessage(String msg, String msgdescription, int msgtype){
+	public void logMessage(String msg, String msgdescription, int msgtype){
 		UniqueStringMessageInfo msgInfo = new UniqueStringMessageInfo(
 											  (String)logid.getUniqueID(),
 											  msg, msgdescription, msgtype);
@@ -116,6 +112,14 @@ public class InputProcessor extends AbstractInputProcessor {
 	 */
 	public String getTestLevel() {
 		return sourceid.getTestLevel();
+	}
+	
+	/***************************************************************************
+	 * Overridden by specific SourceInterface we own.
+	 * @see SourceInterface#getDefaultSeparator()
+	 */
+	public String getDefaultSeparator() {
+		return sourceid.getDefaultSeparator();
 	}
 
 	/***************************************************************************
@@ -300,7 +304,7 @@ public class InputProcessor extends AbstractInputProcessor {
 	 * Process a Driver Command (C,CW,or CF) input record.
 	 * This is called internally by processTest as necessary.
 	 */
-	protected long processDriverCommand(TestRecordHelper trd){
+	public long processDriverCommand(TestRecordHelper trd){
 
 		String command = "";
 		String message = "";
@@ -505,7 +509,7 @@ public class InputProcessor extends AbstractInputProcessor {
 	 * Process a Test (T,TW,or TF) input record.
 	 * This is called internally by processTest as necessary.
 	 */
-	protected long processTestRecord(TestRecordHelper trd){
+	public long processTestRecord(TestRecordHelper trd){
 		
 		// if a STEP, call engines
 		if (isStep) return processComponentFunction(trd);
@@ -550,6 +554,7 @@ public class InputProcessor extends AbstractInputProcessor {
 		// run the test and add status info to existing status info
 		InputProcessor nextLevel = new InputProcessor(this, theSource, alog);
 		StatusInterface nextStatus = nextLevel.processTest();
+		Driver.setIDriver(this);
 		statusCounter.addStatus(nextStatus);
 		TestRecordData nltrd = nextLevel.getTestRecordData();
 		if ((nltrd.getStatusCode()==DriverConstant.STATUS_SCRIPT_NOT_EXECUTED)&&
@@ -597,6 +602,39 @@ public class InputProcessor extends AbstractInputProcessor {
 		return DriverConstant.STATUS_SCRIPT_NOT_EXECUTED;	                          	
 	}
 	
+	public TestRecordHelper initTestRecordData(String record, String separator){
+	    // initialize a new TestRecordData object
+		String trimdata = record.trim();
+	    testRecordData.reinit();
+	    testRecordData.setInputRecord(trimdata);
+	    testRecordData.setSeparator(separator);
+	    try{ 
+	    	String defaultMap = (String) getMapsInterface().getDefaultMap().getUniqueID();
+	    	testRecordData.setAppMapName(defaultMap);
+	    }
+	    catch(ClassCastException ccx){testRecordData.setAppMapName("null");}
+	    catch(NullPointerException npx){testRecordData.setAppMapName("null");}
+
+	    String rt = null;
+
+	    // extract field 1, the record type
+	    try{ 
+	    	rt = testRecordData.getTrimmedUnquotedInputRecordToken(0);
+	    	if (rt.length()==0)	return testRecordData;				
+	    }				
+	    catch(IndexOutOfBoundsException inx){ return testRecordData; }
+	    catch(SAFSNullPointerException npx) { return testRecordData; }			
+
+    	// start filling in the test record data			
+    	testRecordData.setRecordType(rt.toUpperCase()); 
+    	testRecordData.setTestLevel(sourceid.getTestLevel());
+    	testRecordData.setFilename(sourceid.getSourcePath(driver));
+    	testRecordData.setFac((String)logid.getUniqueID());
+    	testRecordData.setStatusCode(DriverConstant.STATUS_SCRIPT_NOT_EXECUTED);
+    	testRecordData.setStatusInfo("");
+    	
+    	return testRecordData;
+	}
 	
 	/***************************************************************************
 	 *  This is the one that actually opens and loops through our tests records!
@@ -622,6 +660,8 @@ public class InputProcessor extends AbstractInputProcessor {
 			counts.incrementAllCounters(counterInfo, counts.STATUS_TEST_FAILURE);
 			return statusCounter;
 		}
+		
+		Driver.setIDriver(this);
 		
 		logMessage(sourceinfo.getTestLevel() +" TABLE: "+ sourceinfo.getSourcePath(driver), 
 		           null, AbstractLogFacility.START_DATATABLE);
@@ -682,17 +722,8 @@ loopbody: {
 				}
 			}
 	    
-		    // initialize a new TestRecordData object
-		    testRecordData.reinit();
-		    testRecordData.setInputRecord(trimdata);
-		    testRecordData.setSeparator(sourceinfo.getDefaultSeparator());
-		    try{ 
-		    	String defaultMap = (String) maps.getDefaultMap().getUniqueID();
-		    	testRecordData.setAppMapName(defaultMap);
-		    }
-		    catch(ClassCastException ccx){testRecordData.setAppMapName("null");}
-		    catch(NullPointerException npx){testRecordData.setAppMapName("null");}
-	    	
+		    // initialize a new TestRecordData object with expressions already resolved
+			testRecordData = initTestRecordData(trimdata, sourceinfo.getDefaultSeparator());
 		    // extract field 1, the record type
 		    try{ 
 		    	rt = testRecordData.getTrimmedUnquotedInputRecordToken(0);
@@ -706,19 +737,8 @@ loopbody: {
 	    		inputerr=false;
 	    		break loopbody;
 	    	}
-
-	    	rt=rt.toUpperCase();
-	    	
-			
-	    	// start filling in the test record data			
-	    	testRecordData.setRecordType(rt); 
-	    	testRecordData.setTestLevel(sourceinfo.getTestLevel());
 	    	testRecordData.setFileID(sourceinfo.getStringID());
-	    	testRecordData.setFilename(sourceinfo.getSourcePath(driver));
 	    	testRecordData.setLineNumber(inputrecord.getRecordNumber());
-	    	testRecordData.setFac((String)logid.getUniqueID());
-	    	testRecordData.setStatusCode(DriverConstant.STATUS_SCRIPT_NOT_EXECUTED);
-	    	testRecordData.setStatusInfo("");
 
 	    	// set DDVariable for active test table like safsActiveCycle=
 	    	getVarsInterface().setValue(activeTableVar, sourceinfo.getFilename());

--- a/src/org/safs/tools/drivers/JSAFSDriver.java
+++ b/src/org/safs/tools/drivers/JSAFSDriver.java
@@ -23,7 +23,6 @@ import org.safs.JavaHook;
 import org.safs.Log;
 import org.safs.SAFSException;
 import org.safs.STAFHelper;
-import org.safs.StatusCodes;
 import org.safs.StringUtils;
 import org.safs.TestRecordData;
 import org.safs.TestRecordHelper;
@@ -33,6 +32,7 @@ import org.safs.model.ComponentFunction;
 import org.safs.model.DriverCommand;
 import org.safs.model.commands.DDDriverCommands;
 import org.safs.model.commands.DriverCommands;
+import org.safs.model.tools.Driver;
 import org.safs.staf.STAFProcessHelpers;
 import org.safs.text.GENStrings;
 import org.safs.tools.DefaultTestRecordStackable;
@@ -40,13 +40,10 @@ import org.safs.tools.ITestRecordStackable;
 import org.safs.tools.UniqueStringID;
 import org.safs.tools.consoles.SAFSMonitorFrame;
 import org.safs.tools.counters.CountStatusInterface;
-import org.safs.tools.counters.CountersInterface;
 import org.safs.tools.counters.UniqueStringCounterInfo;
 import org.safs.tools.engines.EngineInterface;
 import org.safs.tools.input.UniqueStringItemInfo;
 import org.safs.tools.input.UniqueStringMapInfo;
-import org.safs.tools.logs.LogsInterface;
-import org.safs.tools.logs.UniqueStringMessageInfo;
 import org.safs.tools.status.StatusCounter;
 import org.safs.tools.status.StatusInterface;
 
@@ -71,10 +68,10 @@ public class JSAFSDriver extends DefaultDriver implements ITestRecordStackable{
 	public StatusCounter statuscounter = null;
 	public TestRecordHelper testRecordHelper = null;
 
-	/**
-	 * The CounterInfo to send to incrementAllCounters.
-	 */
-	public UniqueStringCounterInfo counterInfo = null;
+//	/**
+//	 * The CounterInfo to send to incrementAllCounters.
+//	 */
+//	public UniqueStringCounterInfo counterInfo = null;
 	
 	/** The ITestRecordStackable used to store 'Test Record' in a FILO. */
 	protected ITestRecordStackable testrecordStackable = new DefaultTestRecordStackable();
@@ -148,32 +145,6 @@ public class JSAFSDriver extends DefaultDriver implements ITestRecordStackable{
 		this.automaticResolve = automaticResolve;
 	}
 	
-	/**
-	 * Routine to log different message types to the active SAFS log.
-	 *  
-	 * @param message String message
-	 * @param description String (optional) for more detailed info.  Can be null.
-	 * @param type int message type constant from AbstractLogFacility.
-	 * <p>  
-	 * Some Message Types:<br/>
-	 * <ul>
-	 * <li>{@link AbstractLogFacility#GENERIC_MESSAGE}
-	 * <li>{@link AbstractLogFacility#PASSED_MESSAGE}
-	 * <li>{@link AbstractLogFacility#FAILED_MESSAGE}
-	 * <li>{@link AbstractLogFacility#FAILED_OK_MESSAGE}
-	 * <li>{@link AbstractLogFacility#WARNING_MESSAGE}
-	 * <li>{@link AbstractLogFacility#WARNING_OK_MESSAGE}
-	 * </ul>
-	 * @see #logGENERIC(String, String)
-	 * @see #logPASSED(String, String)
-	 * @see #logFAILED(String, String)
-	 * @see #logWARNING(String, String)
-	 * @see LogsInterface#logMessage(org.safs.tools.logs.UniqueMessageInterface) 
-	 */
-	public void logMessage(String message, String description, int type){
-		logs.logMessage(new UniqueStringMessageInfo(cycleLog.getStringID(), message, description, type));
-	}
-
 	/**
 	 * Convenience routine to log GENERIC message to the active SAFS log.
 	 * <br>The routine uses the AbstractLogFacility.GENERIC_MESSAGE type.
@@ -601,76 +572,6 @@ public class JSAFSDriver extends DefaultDriver implements ITestRecordStackable{
 		return null;
 	}
 	
-	/**
-	 * Increment General (not Test) record counts.
-	 * @param status
-	 * @see StatusCodes
-	 */
-	public void incrementGeneralStatus(int status){
-		switch(status){		
-			case StatusCodes.OK:
-				statuscounter.incrementGeneralPasses();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_PASS);
-				break;
-			case StatusCodes.INVALID_FILE_IO:
-				statuscounter.incrementIOFailures();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_IO_FAILURE);
-				break;
-			case StatusCodes.GENERAL_SCRIPT_FAILURE:
-			case StatusCodes.WRONG_NUM_FIELDS:
-				statuscounter.incrementGeneralFailures();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_FAILURE);
-				break;
-			case StatusCodes.SCRIPT_WARNING:
-				statuscounter.incrementGeneralWarnings();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_WARNING);
-				break;
-			case StatusCodes.SCRIPT_NOT_EXECUTED:
-				statuscounter.incrementSkippedRecords();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_SKIPPED_RECORD);
-				break;
-			default:
-				statuscounter.incrementGeneralPasses();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_PASS);
-		}
-	}
-
-	/**
-	 * Increment Test Record counts.
-	 * @param status
-	 * @see StatusCodes
-	 */
-	public void incrementTestStatus(int status){
-		switch(status){		
-			case StatusCodes.OK:
-				statuscounter.incrementTestPasses();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_PASS);
-				break;
-			case StatusCodes.INVALID_FILE_IO:
-				statuscounter.incrementTestIOFailures();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_IO_FAILURE);
-				break;
-			case StatusCodes.GENERAL_SCRIPT_FAILURE:
-			case StatusCodes.WRONG_NUM_FIELDS:
-			case StatusCodes.NO_RECORD_TYPE_FIELD:
-			case StatusCodes.UNRECOGNIZED_RECORD_TYPE:
-				statuscounter.incrementTestFailures();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_FAILURE);
-				break;
-			case StatusCodes.SCRIPT_WARNING:
-				statuscounter.incrementTestWarnings();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_TEST_WARNING);
-				break;
-			case StatusCodes.SCRIPT_NOT_EXECUTED:
-				statuscounter.incrementSkippedRecords();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_SKIPPED_RECORD);
-				break;
-			default:
-				statuscounter.incrementGeneralPasses();
-				getCountersInterface().incrementAllCounters(counterInfo, CountersInterface.STATUS_GENERAL_PASS);
-		}
-	}
-
 	/**
 	 * Programmatically conform to user-initiated PAUSE, RUN, STEP, STEP RETRY input from SAFS Monitor.
 	 * <p>
@@ -1265,6 +1166,7 @@ holdloop:	while(! driverStatus.equalsIgnoreCase(JavaHook.RUNNING_EXECUTION)){
 	public static void main(String[] args){
 		log_self("Commencing JSAFS Self-Test...");
 		JSAFSDriver jsafs = new JSAFSDriver("JSAFS");
+		Driver.setIDriver(jsafs);
 		String sep = ","; //default SAFS field separator
 		jsafs.run();
 		
@@ -1353,6 +1255,7 @@ holdloop:	while(! driverStatus.equalsIgnoreCase(JavaHook.RUNNING_EXECUTION)){
 		}catch(SAFSException x){
 			log_self("SAFSMonitor User-Initiated STOP!");
 		}
+		Driver.setIDriver(null);
 		jsafs.shutdown();
 		log_self("Ended JSAFS Self-Test...");
 	}

--- a/src/org/safs/tools/drivers/SAFSDRIVER.java
+++ b/src/org/safs/tools/drivers/SAFSDRIVER.java
@@ -1,12 +1,8 @@
 package org.safs.tools.drivers;
 
+import org.safs.model.tools.Driver;
 import org.safs.tools.UniqueStringID;
-import org.safs.tools.counters.CountersInterface;
-import org.safs.tools.input.InputInterface;
-import org.safs.tools.input.MapsInterface;
 import org.safs.tools.input.UniqueStringFileInfo;
-import org.safs.tools.logs.LogsInterface;
-import org.safs.tools.vars.VarsInterface;
 import org.safs.tools.status.StatusInterface;
 
 /**
@@ -161,6 +157,7 @@ public class SAFSDRIVER extends DefaultDriver {
 		InputProcessor driver = new InputProcessor(this, sourceInfo, testid);
 		
 		StatusInterface statusinfo = driver.processTest();
+		Driver.setIDriver(null);
 		
 		return statusinfo;
 	}


### PR DESCRIPTION
…ssor

By enabling files to use a DriverInterface instead of JSAFSDriver
specifically, we can allow SAFS to provide JSAFS support (Ex: CallJUnit)
with either JSAFSDriver or the SAFS InputProcessor--as both implement
the DriverInterface.
