### PR TITLE
REST: add ability to change client adapter

### DIFF
--- a/src/org/apache/hc/client5/http/testframework/HttpClientPOJOAdapter.java
+++ b/src/org/apache/hc/client5/http/testframework/HttpClientPOJOAdapter.java
@@ -30,6 +30,23 @@ import java.util.Map;
 
 //TODO:  can this class be moved beside HttpClient? (in org.apache.hc.client5.http.sync)
 public abstract class HttpClientPOJOAdapter {
+    public static final String BODY = "body";
+    public static final String CONTENT_TYPE = "contentType";
+    public static final String HEADERS = "headers";
+    public static final String METHOD = "method";
+    public static final String NAME = "name";
+    public static final String OAUTH2_SERVICE_NAME = "oauth2ServiceName";
+    public static final String PASSWORD = "password";
+    public static final String PATH = "path";
+    public static final String PROTOCOL_VERSION = "protocolVersion";
+    public static final String QUERY = "query";
+    public static final String REQUEST = "request";
+    public static final String RESPONSE = "response";
+    public static final String STATUS = "status";
+    public static final String TIMEOUT = "timeout";
+    public static final String USERID = "userid";
+    
+    
     public abstract Map<String, Object> execute(String defaultURI, Map<String, Object> request) throws Exception;
 
     public Map<String, Object> modifyRequest(final Map<String, Object> request) {

--- a/src/org/safs/rest/REST.java
+++ b/src/org/safs/rest/REST.java
@@ -43,19 +43,40 @@ public class REST {
 		return service;
 	}
 
+	/**
+	 * Start a named Service session with a specific web service.<br>
+	 * This doesn't actually make any type of Connection or call to the web service.
+	 * @param serviceId - unique name of the new Service session.
+	 * @param baseURL -- root URL used to interact with the service.
+	 * @param userId -- userId used to interact with the service.
+	 * @param password -- password used to interact with the service.
+	 * @return Service
+	 * @throws IllegalArgumentException if the serviceId is null or already exists.
+	 * @see #EndServiceSession(String)
+	 * @see Services#getService(String)
+	 */
+	public static Service StartServiceSession(String serviceId, String baseURL, String userId, String password) throws IllegalArgumentException{
+		Service service = new Service(serviceId, baseURL, userId, password);
+		Services.addService(service);
+		return service;
+	}
+
 	
 	/**
 	 * Start a named Service session with a specific web service.<br>
 	 * This doesn't actually make any type of Connection or call to the web service.
 	 * @param serviceId - unique name of the new Service session.
 	 * @param baseURL -- root URL used to interact with the service.
+	 * @param userId -- userId used to interact with the service.
+	 * @param password -- password used to interact with the service.
+	 * @param protocolVersion -- protocol version used to interact with the service.
 	 * @return Service
 	 * @throws IllegalArgumentException if the serviceId is null or already exists.
 	 * @see #EndServiceSession(String)
 	 * @see Services#getService(String)
 	 */
-	public static Service StartServiceSession(String serviceId, String baseURL, String protocolVersion) throws IllegalArgumentException{
-		Service service = new Service(serviceId, baseURL, protocolVersion);
+	public static Service StartServiceSession(String serviceId, String baseURL, String userId, String password, String protocolVersion) throws IllegalArgumentException{
+		Service service = new Service(serviceId, baseURL, userId, password, protocolVersion);
 		Services.addService(service);
 		return service;
 	}

--- a/src/org/safs/rest/service/RESTImpl.java
+++ b/src/org/safs/rest/service/RESTImpl.java
@@ -1,14 +1,15 @@
 package org.safs.rest.service;
 
+import static org.apache.hc.client5.http.testframework.HttpClientPOJOAdapter.OAUTH2_SERVICE_NAME;
+import static org.apache.hc.client5.http.testframework.HttpClientPOJOAdapter.PASSWORD;
+import static org.apache.hc.client5.http.testframework.HttpClientPOJOAdapter.USERID;
+
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hc.client5.http.testframework.HttpClient5Adapter;
 import org.apache.hc.client5.http.testframework.HttpClientPOJOAdapter;
 import org.apache.hc.client5.http.utils.URLEncodedUtils;
 import org.apache.hc.core5.http.NameValuePair;
@@ -16,8 +17,6 @@ import org.apache.hc.core5.http.ProtocolVersion;
 
 public class RESTImpl {
 	
-	private HttpClientPOJOAdapter implAdapter = new HttpClient5Adapter();
-
 	public Response request(String serviceId, String requestMethod, String relativeURI, String headers,
 			Object body) throws Exception {
 		
@@ -47,13 +46,18 @@ public class RESTImpl {
 		request.put("body", body);
 		request.put("contentType", headersMap.get(Headers.CONTENT_TYPE));
 		request.put("protocolVersion", protVersion);
+		request.put(USERID, service.getUserId());
+		request.put(PASSWORD, service.getPassword());
+		request.put(OAUTH2_SERVICE_NAME, service.getOauth2ServiceName());
 
 		headersMap.remove(Headers.CONTENT_TYPE);
 		
 		long defaultTimeout = Timeouts.getDefaultTimeouts().getMillisToTimeout();
 		request.put("timeout", defaultTimeout);
 		
-		Map<String,Object> response = implAdapter.execute(defaultURI, request);
+		HttpClientPOJOAdapter clientAdapter = (HttpClientPOJOAdapter) service.getClientAdapter();
+
+		Map<String,Object> response = clientAdapter.execute(defaultURI, request);
 		
 		int status = (int) response.get("status");
 		

--- a/src/org/safs/rest/service/Service.java
+++ b/src/org/safs/rest/service/Service.java
@@ -4,6 +4,7 @@
  */
 package org.safs.rest.service;
 
+import org.apache.hc.client5.http.testframework.HttpClient5Adapter;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.safs.SAFSRuntimeException;
@@ -25,7 +26,9 @@ public class Service{
 	private String password;
 	private String authType;
 	private ProtocolVersion protocolVersion = HttpVersion.HTTP_1_1;
-	
+	private String oauth2ServiceName;
+	private String clientAdapterClassName;
+	private Object clientAdapter;
 	
 	/**
 	 * Constructor
@@ -49,10 +52,26 @@ public class Service{
 	 * Constructor
 	 * @param serviceId
 	 * @param baseURL
+	 * @param userId
+	 * @param password
+	 */
+	public Service(String serviceId, String baseURL, String userId, String password) {
+		this(serviceId, baseURL);
+		setUserId(userId);
+		setPassword(password);
+		setOauth2ServiceName(oauth2ServiceName);
+	}
+
+	/**
+	 * Constructor
+	 * @param serviceId
+	 * @param baseURL
+	 * @param userId
+	 * @param password
 	 * @param protocolVersion
 	 */
-	public Service(String serviceId, String baseURL, String protocolVersion) {
-		this(serviceId, baseURL);
+	public Service(String serviceId, String baseURL, String userId, String password, String protocolVersion) {
+		this(serviceId, baseURL, userId, password);
 		setProtocolVersion(protocolVersion);
 	}
 
@@ -173,5 +192,47 @@ public class Service{
 	// for internal use only
 	ProtocolVersion getProtocolVersionObject() {
 		return protocolVersion;
+	}
+	
+	/**
+	 * @param oauth2ServiceName the service name of the oauth2 service
+	 */
+	public void setOauth2ServiceName(String oauth2ServiceName) {
+		this.oauth2ServiceName = oauth2ServiceName;
+	}
+
+	// for internal use only
+	String getOauth2ServiceName() {
+		return oauth2ServiceName;
+	}
+	
+	/**
+	 * To specify the use of a different client adapter, call this
+	 * with the class name of the adapter.
+	 * 
+	 * @param clientAdapterClassName the class name of the client adapter
+	 */
+	public void setClientAdapterClassName(String clientAdapterClassName) {
+		this.clientAdapterClassName = clientAdapterClassName;
+	}
+	
+	// for internal use only
+	String getClientAdapterClassName() {
+		return clientAdapterClassName;
+	}
+
+	// for internal use only
+	public Object getClientAdapter() throws Exception {
+		if (clientAdapter == null) {
+			if (clientAdapterClassName == null) {
+				// use HttpClient5 by default
+				clientAdapter = new HttpClient5Adapter();
+			} else {
+				Class<?> clazz = Class.forName(clientAdapterClassName);
+				clientAdapter = clazz.newInstance();
+			}
+		}
+		
+		return clientAdapter;
 	}
 }


### PR DESCRIPTION
Let me know if you see a problem with this change.  Most of it is easy to follow, but I do want to point out that I moved the adapter from the RESTImpl to the Service.  It was called implAdapter before, but I changed it to clientAdapter.

Now, if a user does not want to use the default HttpClient5 adapter, they can insert their own adapter by calling service.setClientAdapterClassName("my.adapter.class.name").
