### PR TITLE
REST: add ability to change client adapter - take2

### DIFF
--- a/src/org/apache/hc/client5/http/testframework/HttpClientPOJOAdapter.java
+++ b/src/org/apache/hc/client5/http/testframework/HttpClientPOJOAdapter.java
@@ -30,6 +30,23 @@ import java.util.Map;
 
 //TODO:  can this class be moved beside HttpClient? (in org.apache.hc.client5.http.sync)
 public abstract class HttpClientPOJOAdapter {
+    public static final String BODY = "body";
+    public static final String CONTENT_TYPE = "contentType";
+    public static final String HEADERS = "headers";
+    public static final String METHOD = "method";
+    public static final String NAME = "name";
+    public static final String OAUTH2_SERVICE_NAME = "oauth2ServiceName";
+    public static final String PASSWORD = "password";
+    public static final String PATH = "path";
+    public static final String PROTOCOL_VERSION = "protocolVersion";
+    public static final String QUERY = "query";
+    public static final String REQUEST = "request";
+    public static final String RESPONSE = "response";
+    public static final String STATUS = "status";
+    public static final String TIMEOUT = "timeout";
+    public static final String USERID = "userid";
+    
+    
     public abstract Map<String, Object> execute(String defaultURI, Map<String, Object> request) throws Exception;
 
     public Map<String, Object> modifyRequest(final Map<String, Object> request) {

--- a/src/org/safs/rest/service/RESTImpl.java
+++ b/src/org/safs/rest/service/RESTImpl.java
@@ -1,9 +1,10 @@
 package org.safs.rest.service;
 
+import static org.apache.hc.client5.http.testframework.HttpClientPOJOAdapter.PASSWORD;
+import static org.apache.hc.client5.http.testframework.HttpClientPOJOAdapter.USERID;
+
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,13 +48,17 @@ public class RESTImpl {
 		request.put("body", body);
 		request.put("contentType", headersMap.get(Headers.CONTENT_TYPE));
 		request.put("protocolVersion", protVersion);
+		request.put(USERID, service.getUserId());
+		request.put(PASSWORD, service.getPassword());
 
 		headersMap.remove(Headers.CONTENT_TYPE);
 		
 		long defaultTimeout = Timeouts.getDefaultTimeouts().getMillisToTimeout();
 		request.put("timeout", defaultTimeout);
 		
-		Map<String,Object> response = implAdapter.execute(defaultURI, request);
+		HttpClientPOJOAdapter clientAdapter = (HttpClientPOJOAdapter) service.getClientAdapter();
+
+		Map<String,Object> response = clientAdapter.execute(defaultURI, request);
 		
 		int status = (int) response.get("status");
 		

--- a/src/org/safs/rest/service/Service.java
+++ b/src/org/safs/rest/service/Service.java
@@ -4,6 +4,7 @@
  */
 package org.safs.rest.service;
 
+import org.apache.hc.client5.http.testframework.HttpClient5Adapter;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.safs.SAFSRuntimeException;
@@ -25,7 +26,8 @@ public class Service{
 	private String password;
 	private String authType;
 	private ProtocolVersion protocolVersion = HttpVersion.HTTP_1_1;
-	
+	private String clientAdapterClassName;
+	private Object clientAdapter;
 	
 	/**
 	 * Constructor
@@ -173,5 +175,36 @@ public class Service{
 	// for internal use only
 	ProtocolVersion getProtocolVersionObject() {
 		return protocolVersion;
+	}
+	
+	/**
+	 * To specify the use of a different client adapter, call this
+	 * with the class name of the adapter.
+	 * 
+	 * @param clientAdapterClassName the class name of the client adapter
+	 */
+	public Object setClientAdapterClassName(String clientAdapterClassName) throws Exception {
+		this.clientAdapterClassName = clientAdapterClassName;
+		return getClientAdapter();
+	}
+	
+	// for internal use only
+	String getClientAdapterClassName() {
+		return clientAdapterClassName;
+	}
+
+	// for internal use only
+	Object getClientAdapter() throws Exception {
+		if (clientAdapter == null) {
+			if (clientAdapterClassName == null) {
+				// use HttpClient5 by default
+				clientAdapter = new HttpClient5Adapter();
+			} else {
+				Class<?> clazz = Class.forName(clientAdapterClassName);
+				clientAdapter = clazz.newInstance();
+			}
+		}
+		
+		return clientAdapter;
 	}
 }


### PR DESCRIPTION
After a one-on-one with Carl, I have reduced the changes just to allow the user to change the client adapter.

As stated in the previous pull request, I moved the adapter from the RESTImpl to the Service. It was called implAdapter before, but I changed it to clientAdapter.

Now, if a user does not want to use the default HttpClient5 adapter, they can insert their own adapter by calling service.setClientAdapterClassName("my.adapter.class.name").  An instance of that class will be returned so the user can call setters on it.
