### PR TITLE
Enable running without install

### DIFF
--- a/src/org/safs/selenium/util/SePlusInstallInfo.java
+++ b/src/org/safs/selenium/util/SePlusInstallInfo.java
@@ -194,15 +194,22 @@ public class SePlusInstallInfo{
 		return cp;
 	}
 
+	/**
+	 * If the override property is set, then use of the installed product is not
+	 * desired.  This would especially be true during testing.  During testing
+	 * the use of the latest files is desired versus what might be installed.
+	 *
+	 * @return true if the override property is set to "true" (ex. SELENIUM_PLUS_OVERRIDE).
+	 */
 	public static boolean isOverridePropertySet(String env){
-		/*
-		 * If the override property is set, then use of the installed product is not
-		 * desired.  This would especially be true during testing, but it
-		 * also applies when the SeleniumPlusClient is being used.
-		 */
 		return Boolean.getBoolean(env + "_OVERRIDE");
 	}
 
+	/**
+	 * If the override property is set to true (ex. SELENIUM_PLUS_OVERRIDE),
+	 * use the value of the system property (ex. SELENIUM_PLUS).  Otherwise,
+	 * use the environment variable.
+	 */
 	public static String GetSystemPropertyOrEnvironmentVariable(String env){
 		String result = null;
 

--- a/src/org/safs/selenium/util/SePlusInstallInfo.java
+++ b/src/org/safs/selenium/util/SePlusInstallInfo.java
@@ -194,10 +194,31 @@ public class SePlusInstallInfo{
 		return cp;
 	}
 
+	public static boolean isOverridePropertySet(String env){
+		/*
+		 * If the override property is set, then use of the installed product is not
+		 * desired.  This would especially be true during testing, but it
+		 * also applies when the SeleniumPlusClient is being used.
+		 */
+		return Boolean.getBoolean(env + "_OVERRIDE");
+	}
+
+	public static String GetSystemPropertyOrEnvironmentVariable(String env){
+		String result = null;
+
+		boolean override = isOverridePropertySet(env);
+		result = override ? System.getProperty(env) : null;
+
+		if (result==null){
+			result = System.getenv(env);
+		}
+		return result;
+	}
+
 	protected static String GetSystemEnvironmentVariable(String env){
 		Object result = null;
 
-		result = System.getenv(env);
+		result = GetSystemPropertyOrEnvironmentVariable(env);
 
 		String nativeWrapperClassName = "org.safs.natives.NativeWrapper";
 		Class<?> nativeWrapperClass = null;
@@ -493,7 +514,7 @@ public class SePlusInstallInfo{
 	private static boolean IsProduct(String environmentHome, String indicator){
 		String sourceLocation = getSourceLocation().toLowerCase();
 
-		String home = GetSystemEnvironmentVariable(environmentHome);
+		String home = GetSystemPropertyOrEnvironmentVariable(environmentHome);
 
 		if(home!=null){
 			//replace backslash "\" by slash "/"

--- a/src/org/safs/selenium/webdriver/WebDriverGUIUtilities.java
+++ b/src/org/safs/selenium/webdriver/WebDriverGUIUtilities.java
@@ -183,6 +183,9 @@ public class WebDriverGUIUtilities extends DDGUIUtilities {
 		return SePlusInstallInfo.IsSeleniumPlus();
 	}
 
+	/**
+	 * @return the location of the SeleniumPlus files.
+	 */
 	public static String getSeleniumPlusHome(){
 		return SePlusInstallInfo.GetSystemPropertyOrEnvironmentVariable(DriverConstant.SYSTEM_PROPERTY_SELENIUMPLUS_DIR);
 	}

--- a/src/org/safs/selenium/webdriver/WebDriverGUIUtilities.java
+++ b/src/org/safs/selenium/webdriver/WebDriverGUIUtilities.java
@@ -183,6 +183,10 @@ public class WebDriverGUIUtilities extends DDGUIUtilities {
 		return SePlusInstallInfo.IsSeleniumPlus();
 	}
 
+	public static String getSeleniumPlusHome(){
+		return SePlusInstallInfo.GetSystemPropertyOrEnvironmentVariable(DriverConstant.SYSTEM_PROPERTY_SELENIUMPLUS_DIR);
+	}
+
 	/**
 	 * @return true if we detect we are running from a SAFS installation (/lib/safsselenium.jar)
 	 */
@@ -357,7 +361,7 @@ public class WebDriverGUIUtilities extends DDGUIUtilities {
 						if(isSAFS()){
 							safsdir = System.getenv(DriverConstant.SYSTEM_PROPERTY_SAFS_DIR)+ File.separator+"lib"+File.separator;
 						}else{//isSeleniumPlus
-							safsdir = System.getenv(DriverConstant.SYSTEM_PROPERTY_SELENIUMPLUS_DIR)+ File.separator +"libs"+File.separator;
+							safsdir = getSeleniumPlusHome()+ File.separator +"libs"+File.separator;
 						}
 						File custurl = new CaseInsensitiveFile(safsdir + CUSTOM_CLASS2TYPE_MAP).toFile();
 						if(custurl.isFile()) in = custurl.toURL().openStream();
@@ -1148,7 +1152,7 @@ public class WebDriverGUIUtilities extends DDGUIUtilities {
 		File executable = null;
 
 		if(isSeleniumPlus()){
-			root = System.getenv("SELENIUM_PLUS");
+			root = getSeleniumPlusHome();
 			server = root + "/extra/RemoteServer.bat";
 			executable = new File(server);
 		}
@@ -1164,7 +1168,7 @@ public class WebDriverGUIUtilities extends DDGUIUtilities {
 			}else{
 				IndependantLog.warn("WDGU: startRemoteServer executable '"+executable.getAbsolutePath()+"' doesn't not exist.");
 			}
-			root = System.getenv("SELENIUM_PLUS");
+			root = getSeleniumPlusHome();
 			server = root + "/extra/RemoteServer.bat";
 			executable = new File(server);
 			if(!executable.exists()){


### PR DESCRIPTION
Please let me know if you see a problem with doing this.   If SELENIUM_PLUS_OVERRIDE is set to true, use the SELENIUM_PLUS system property (if set) instead of the environment variable.  This allows the use of a particular version of SeleniumPlus instead of one that might happen to be installed.  This would be especially helpful in some testing scenarios where you want to test the latest version of SeleniumPlus instead of what might be installed.