### PR TITLE
Move SELENIUM_PLUS_ENV.

### DIFF
--- a/src/org/safs/seleniumplus/projects/BaseProject.java
+++ b/src/org/safs/seleniumplus/projects/BaseProject.java
@@ -1,0 +1,6 @@
+package org.safs.seleniumplus.projects;
+
+public class BaseProject {
+	/** "SELENIUM_PLUS" the system environment variable name holding the path where SeleniumPlus has been installed */
+	public static final String SELENIUM_PLUS_ENV = "SELENIUM_PLUS";
+}

--- a/src/org/safs/seleniumplus/projects/BaseProject.java
+++ b/src/org/safs/seleniumplus/projects/BaseProject.java
@@ -1,6 +1,6 @@
 package org.safs.seleniumplus.projects;
 
 public class BaseProject {
-	/** "SELENIUM_PLUS" the system environment variable name holding the path where SeleniumPlus has been installed */
-	public static final String SELENIUM_PLUS_ENV = "SELENIUM_PLUS";
+	/** holds path to SeleniumPlus install directory -- once validated. */
+	public static String SELENIUM_PLUS;
 }

--- a/src/org/safs/seleniumplus/projects/BaseProject.java
+++ b/src/org/safs/seleniumplus/projects/BaseProject.java
@@ -3,4 +3,7 @@ package org.safs.seleniumplus.projects;
 public class BaseProject {
 	/** holds path to SeleniumPlus install directory -- once validated. */
 	public static String SELENIUM_PLUS;
+
+	/** "Tests" */
+	public static final String SRC_TEST_DIR = "Tests";
 }


### PR DESCRIPTION
SELENIUM_PLUS_ENV is moved from com.sas.seleniumplus.projects.BaseProject to org.safs.seleniumplus.projects.BaseProject in SAFS Core.

Let me know if you see a problem.  I am wanting to move some functionality that is in the SeleniumPlus-Plugin project into Core.  For now, I am moving the SELENIUM_PLUS_ENV constant.  That constant was in the SeleniumPlus-Plugin project in com.sas.seleniumplus.projects.BaseProject.  I am moving it to a class called org.safs.seleniumplus.projects.BaseProject.